### PR TITLE
Optionally override interface style of presented view controller.

### DIFF
--- a/Sources/SheeKit/SheetHostingController.swift
+++ b/Sources/SheeKit/SheetHostingController.swift
@@ -71,6 +71,10 @@ final class SheetHostingController<Item>: UIHostingController<AnyView> where Ite
             setNeedsUpdateOfPrefersPointerLocked()
         }
         
+        if let style = proxy.overrideUserInterfaceStyle {
+            overrideUserInterfaceStyle = style
+        }
+        
         overridePrefersHomeIndicatorAutoHidden = proxy.prefersHomeIndicatorAutoHidden
         
         if overridePreferredScreenEdgesDeferringSystemGestures != proxy.preferredScreenEdgesDeferringSystemGestures {

--- a/Sources/SheeKit/UIViewControllerProxy.swift
+++ b/Sources/SheeKit/UIViewControllerProxy.swift
@@ -32,6 +32,13 @@ import UIKit
 /// The proxy with preferred parameters of the presented view controller that hosts the presented `View`.
 public struct UIViewControllerProxy {
     
+    /// Optionally override the interface style of the presented view controller.
+    ///
+    /// This property allows optionally overriding the interface style of the prsented view contoller if set
+    /// To change the interface sytle, you must set this property before presenting the `View`. The default value for this property is `nil, which results in inherting the interface style of the current application `.
+    /// Possible interface styles are .dark, .light. See the documenation for UIUserInterfaceStyle for more details.
+    public var overrideUserInterfaceStyle: UIUserInterfaceStyle? = nil
+    
     /// The transition style to use when presenting the view controller.
     ///
     /// This property determines how the `View` is animated onscreen when it is presented.


### PR DESCRIPTION
This PR allows overriding the interface style of the presented view controller. Specifically, it adds the ability to set the `overrideUserInterfaceStyle` property on the view controller before it is presented. This allows omitting the `.preferredColorScheme(.dark)` modifier, which didn't seem to survive the presentation and retroactively caused interface style changes in the view calling `.shee(`.... 